### PR TITLE
#279 'Path must be normalized' code generation error on Windows

### DIFF
--- a/package/lib/src/backend/core/find_package_path_by_import.dart
+++ b/package/lib/src/backend/core/find_package_path_by_import.dart
@@ -51,11 +51,11 @@ Future<String?> findDartFileFromUri({
     throw PackageNotInstalledException(packageName: packageName);
   }
 
-  return Uri.parse(path.join(
+  return path.join(
     path.isRelative(targetPackage.rootUri.path) ? projectDirectoryPath : targetPackage.rootUri.path,
-    targetPackage.packageUri.path,
-    uri.substring(1 + uri.indexOf('/')),
-  )).toString();
+    path.normalize(targetPackage.packageUri.path),
+    path.basename(uri),
+  );
 }
 
 @DataClass(copyWith: false)


### PR DESCRIPTION
Code generation indexing fails on Windows when parsing directives.

```
Unhandled exception:
Invalid argument(s): Path must be normalized : d:/workspace/Flutter/Packages/data_class_plugin/examples/file_generation_mode/lib/data_class.dart
#0      PhysicalResourceProvider._ensureAbsoluteAndNormalized.<anonymous closure> (package:analyzer/file_system/physical_file_system.dart:88:9)
#1      PhysicalResourceProvider._ensureAbsoluteAndNormalized (package:analyzer/file_system/physical_file_system.dart:91:6)
#2      PhysicalResourceProvider.getResource (package:analyzer/file_system/physical_file_system.dart:62:5)
#3      parseFile (package:analyzer/dart/analysis/utilities.dart:45:35)
#4      ParseFileX.parse (package:data_class_plugin/src/backend/core/parse_file_extension.dart:11:38)
#5      CodeGenerator.indexProject.index (package:data_class_plugin/src/backend/code_generator.dart:139:30)
<asynchronous suspension>
#6      CodeGenerator.indexProject (package:data_class_plugin/src/backend/code_generator.dart:164:7)
```